### PR TITLE
fix: mozilla data policy

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -18,7 +18,10 @@ const perBrowserManifest: Record<string, UserManifest> = {
         permissions: [...BASE_PERMISSIONS, 'notifications'],
         browser_specific_settings: {
             gecko: {
-                id: 'chorus@cdrani.dev'
+                id: 'chorus@cdrani.dev',
+                data_collection_permissions: {
+                    required: ['none']
+                }
             }
         }
     }


### PR DESCRIPTION
Address new Mozilla Data Policies in Firefox browsers v140+.

Manifest key needs to include new [`data_collection_pemissions`](https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/) key.

Chorus does not collect any data so it's set to none. Hopefully this gets chorus back into the addon store. 🙏 